### PR TITLE
Resolved PSR-4 warning when installing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
         "psr-4": {
             "Aspose\\Slides\\Cloud\\Sdk\\": "sdk/",
             "Aspose\\Slides\\Cloud\\Sdk\\Model\\": "sdk/model/",
-            "Aspose\\Slides\\Cloud\\Sdk\\Api\\": "sdk/api/",
+            "Aspose\\Slides\\Cloud\\Sdk\\Api\\": "sdk/api/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Aspose\\Slides\\Cloud\\Sdk\\Tests\\": "tests/",
             "Aspose\\Slides\\Cloud\\Sdk\\Tests\\Api\\": "tests/api/",
             "Aspose\\Slides\\Cloud\\Sdk\\Tests\\UseCases\\": "tests/usecases/",


### PR DESCRIPTION
When installing this package in other projects, composer would complain that classes in the `tests` folder don't comply with PSR-4:

```
Generating optimized autoload files
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\ShapeFormatTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/ShapeFormatTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\ImageTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/ImageTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\SplitTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/SplitTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\TableTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/TableTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\MathTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/MathTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Aspose\Slides\Cloud\Sdk\Tests\UseCases\TextFormatTest located in ./vendor/aspose/slides-sdk-php/tests/useCases/TextFormatTest.php does not comply with psr-4 autoloading standard. Skipping.
...
```

As these files aren't necessary outside of this repository, we can split them into the [`autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev) section to prevent them from being read in production installs, or polluting the autoloader when this package is required by another project.